### PR TITLE
Added to npm. Update readme with installation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Integrate Chosen with Ractive, including two-way binding.
 
 [See the demo here.](http://kalcifer.github.io/ractive-decorators-chosen/)
 
+Installation
+-----
+
+`npm install ractive-decorators-chosen`
+
+or
+
+`bower install ractive-decorators-chosen`
+
+
 Usage
 -----
 


### PR DESCRIPTION
I would like to use ractive-decorators-chosen with browserify, which uses npm for packages. I added this to the npm registry at https://www.npmjs.com/package/ractive-decorators-chosen
